### PR TITLE
Fixed clear linux fetching

### DIFF
--- a/pika-apx-configs/usr/share/apx/stacks/clear-linux.yaml
+++ b/pika-apx-configs/usr/share/apx/stacks/clear-linux.yaml
@@ -1,5 +1,5 @@
 name: clear-linux
-base: clearlinux:latest
+base: docker.io/library/clearlinux:latest
 packages: []
 pkgmanager: swupd
 builtin: true


### PR DESCRIPTION
For reasons not apparent, clearlinux:latest does not allow apx to fetch the clear linux image from docker hub, must use the URL I added to the clear linux stack config instead, then everything works as intended.